### PR TITLE
SubscriptionAddon, method replaces with properties

### DIFF
--- a/ChargeBee/Models/Subscription.cs
+++ b/ChargeBee/Models/Subscription.cs
@@ -2559,27 +2559,14 @@ namespace ChargeBee.Models
         #region Subclasses
         public class SubscriptionAddon : Resource
         {
+            public string Id { get => GetValue<string>("id", true); }
 
-            public string Id() {
-                return GetValue<string>("id", true);
-            }
+            public int? Quantity { get => GetValue<int?>("quantity", false); }
+            public int? GetUnitPrice { get => GetValue<int?>("unit_price", false); }
 
-            public int? Quantity() {
-                return GetValue<int?>("quantity", false);
-            }
+            public DateTime? TrialEnd { get => GetDateTime("trial_end", false); }
 
-            public int? UnitPrice() {
-                return GetValue<int?>("unit_price", false);
-            }
-
-            public DateTime? TrialEnd() {
-                return GetDateTime("trial_end", false);
-            }
-
-            public int? RemainingBillingCycles() {
-                return GetValue<int?>("remaining_billing_cycles", false);
-            }
-
+            public int? RemainingBillingCycles { get => GetValue<int?>("remaining_billing_cycles", false); }
         }
         public class SubscriptionCoupon : Resource
         {


### PR DESCRIPTION
SubscriptionAddon couldn't automatically serialise to JSON due to the class having methods instead of properties. Methods now replaces with properties.

This could, and would, introduce issues for anyone currently using these methods.